### PR TITLE
[FIX] #75 장소 상세에서 지도가 표시되지 않는 오류를 수정

### DIFF
--- a/app/src/main/java/com/comjeong/nomadworker/ui/place/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/comjeong/nomadworker/ui/place/PlaceDetailFragment.kt
@@ -64,6 +64,31 @@ class PlaceDetailFragment : BaseFragment<FragmentPlaceDetailBinding>(R.layout.fr
 
     }
 
+    override fun onStart() {
+        super.onStart()
+        mMapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mMapView.onStop()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mMapView.onResume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mMapView.onLowMemory()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mMapView.onSaveInstanceState(outState)
+    }
+
     private fun observePlaceDetailInfo() {
         viewModel.placeDetailInfo.observe(viewLifecycleOwner) { detailInfo ->
             binding.placeInfo = detailInfo


### PR DESCRIPTION
## :fireworks: 관련 이슈

close #75

## :fireworks: PR Point

- 구글맵 관련 생명주기 코드를 추가하여 지도가 화면상에 표시되도록 고침
